### PR TITLE
NGR-1328 Validate case-insensitive NINO while persisting it upper case

### DIFF
--- a/app/uk/gov/hmrc/ngrloginregisterfrontend/controllers/NinoController.scala
+++ b/app/uk/gov/hmrc/ngrloginregisterfrontend/controllers/NinoController.scala
@@ -18,13 +18,13 @@ package uk.gov.hmrc.ngrloginregisterfrontend.controllers
 
 import play.api.data.Form
 import play.api.i18n.I18nSupport
-import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import play.api.mvc.{Action, AnyContent, AnyContentAsFormUrlEncoded, MessagesControllerComponents}
 import uk.gov.hmrc.ngrloginregisterfrontend.actions.{AuthRetrievals, HasMandotoryDetailsAction, RegistrationAction}
 import uk.gov.hmrc.ngrloginregisterfrontend.config.AppConfig
 import uk.gov.hmrc.ngrloginregisterfrontend.models.forms.Nino
 import uk.gov.hmrc.ngrloginregisterfrontend.models.forms.Nino.form
 import uk.gov.hmrc.ngrloginregisterfrontend.models.registration.ReferenceType.NINO
-import uk.gov.hmrc.ngrloginregisterfrontend.models.registration.{CredId, TRNReferenceNumber}
+import uk.gov.hmrc.ngrloginregisterfrontend.models.registration.{CredId, RatepayerRegistrationValuationRequest, TRNReferenceNumber}
 import uk.gov.hmrc.ngrloginregisterfrontend.repo.RatepayerRegistrationRepo
 import uk.gov.hmrc.ngrloginregisterfrontend.views.html.NinoView
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -65,8 +65,9 @@ class NinoController @Inject()(
     }
   }
 
-  def submit(): Action[AnyContent] =
-    (authenticate andThen isRegisteredCheck andThen hasMandotoryDetailsAction).async { implicit request =>
+  def submit(): Action[AnyContent] = {
+    (authenticate andThen isRegisteredCheck andThen hasMandotoryDetailsAction).async { r =>
+      implicit val request = withUpperCaseNino(r)
       val authNino = request.ratepayerRegistration.flatMap{ ratePayer =>
         ratePayer match {
           case ratePayer if ratePayer.nino.isDefined == true => ratePayer.nino
@@ -83,5 +84,22 @@ class NinoController @Inject()(
           }
         )
     }
+  }
+
+  // This method ensures that the eventually given NINO is always in uppercase,
+  // regardless of how the user entered it, before processing the request further
+  private def withUpperCaseNino(rrvr: RatepayerRegistrationValuationRequest[AnyContent]): RatepayerRegistrationValuationRequest[AnyContent] = {
+    rrvr.body.asFormUrlEncoded match {
+      case Some(formData) =>
+        val nino = formData.get(Nino.nino).flatMap(_.headOption).map(_.toUpperCase)
+        nino match {
+          case Some(value) => rrvr.copy(
+            request = rrvr.request.withBody(AnyContentAsFormUrlEncoded(formData.updated(Nino.nino, Seq(value))))
+          )
+          case None => rrvr
+        }
+      case None => rrvr
+    }
+  }
 }
 

--- a/app/uk/gov/hmrc/ngrloginregisterfrontend/views/NinoView.scala.html
+++ b/app/uk/gov/hmrc/ngrloginregisterfrontend/views/NinoView.scala.html
@@ -26,7 +26,7 @@
 @this(
 layout: Layout,
 govukSummaryList : GovukSummaryList,
-inputText: components.InputText,
+inputText: InputText,
 formHelper: FormWithCSRF,
 govukErrorSummary: GovukErrorSummary,
 govukFieldset: GovukFieldset,

--- a/test/uk/gov/hmrc/ngrloginregisterfrontend/controllers/NinoControllerSpec.scala
+++ b/test/uk/gov/hmrc/ngrloginregisterfrontend/controllers/NinoControllerSpec.scala
@@ -109,12 +109,12 @@ class NinoControllerSpec extends ControllerSpecSupport {
 
     "method submit" must {
       "Successfully submit valid matching nino and redirect to confirm contact details" in {
-        val result = controller().submit()(AuthenticatedUserRequest(FakeRequest(routes.NinoController.submit).withFormUrlEncodedBody(("nino-value", "AA000003D")).withHeaders(HeaderNames.authorisation -> "Bearer 1"), None, None, None, None, None, None, nino = authNino(hasNino = true, Some(""))))
+        val result = controller().submit()(AuthenticatedUserRequest(FakeRequest(routes.NinoController.submit).withFormUrlEncodedBody(("nino-value", "aa000003D")).withHeaders(HeaderNames.authorisation -> "Bearer 1"), None, None, None, None, None, None, nino = authNino(hasNino = true, Some(""))))
         status(result) mustBe SEE_OTHER
       }
 
       "Successfully submit valid matching nino that contains spaces and redirect to confirm contact details" in {
-        val result = controller().submit()(AuthenticatedUserRequest(FakeRequest(routes.NinoController.submit).withFormUrlEncodedBody(("nino-value", "AA 00 00 03 D")).withHeaders(HeaderNames.authorisation -> "Bearer 1"), None, None, None, None, None, None, nino = authNino(hasNino = true, Some(""))))
+        val result = controller().submit()(AuthenticatedUserRequest(FakeRequest(routes.NinoController.submit).withFormUrlEncodedBody(("nino-value", "AA 00 00 03 d")).withHeaders(HeaderNames.authorisation -> "Bearer 1"), None, None, None, None, None, None, nino = authNino(hasNino = true, Some(""))))
         status(result) mustBe SEE_OTHER
       }
 


### PR DESCRIPTION
This commit makes sure that 
* NINO are being validate regardless of how users entered them (by entering upper case letters, or lower case letters or any combination of them)
* after validation succeeds, NINO are always persisted as upper case into the database

<img width="729" height="558" alt="Screenshot 2025-07-10 at 11 27 47" src="https://github.com/user-attachments/assets/6e17eb80-19a4-407b-8f0d-dbe417247981" />

